### PR TITLE
Add magic fix for analog O3 runs

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1,4 +1,5 @@
 #include "utils.h"
+#define DELAY 200000000
 
 L2_DATA uint32_t configuration_register[16] = {0};
 L2_DATA Instruction_memory_object_analog instruction_memory_compiled_analog[2] = {0};
@@ -108,8 +109,7 @@ static inline void wait_pin(int pin, int pol){
     }
 }
 
-void boot_diana(){
-
+void __attribute__((noinline, optimize("O0"))) boot_diana(){
   //----------------SIZING THE .H DATA--------------------------------
   volatile int size_array_cr_ania=sizeof(cra_boot)/sizeof(cra_boot[0]);
 
@@ -134,4 +134,9 @@ void boot_diana(){
   global_sync_analog();
   reset_pin(17);
   wait_pin(18,0);
+  // Wait a while
+  for(int i = 0; i < DELAY; i++){
+    // do nothing!
+    ;
+  }
 }


### PR DESCRIPTION
This fix adds a nooptimize attribute to the boot procedure and also inserts a stray loop there to wait a few more cycles before proceeding from boot.

I don't know why this works or how it works, but it works. We observed this because stepping through the code line-by-line with GDB worked, but doing a full automatic run didn't. Since the for loop is only inserted in the boot procedure (which is called only once in the beginning, it does not affect normal operation in any way, but it might make boot a little slower.